### PR TITLE
Fix broken star history charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,10 +413,10 @@ If you use MOSS-Transcribe-Diarize, please cite the technical report:
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=OpenMOSS%2FMOSS-Transcribe-Diarize&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#OpenMOSS/MOSS-Transcribe-Diarize&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=OpenMOSS/MOSS-Transcribe-Diarize&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=OpenMOSS/MOSS-Transcribe-Diarize&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=OpenMOSS/MOSS-Transcribe-Diarize&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=OpenMOSS/MOSS-Transcribe-Diarize&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=OpenMOSS/MOSS-Transcribe-Diarize&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=OpenMOSS/MOSS-Transcribe-Diarize&type=date&legend=top-left" />
  </picture>
 </a>

--- a/README_zh.md
+++ b/README_zh.md
@@ -412,10 +412,10 @@ mtd-subtitle /path/to/input.mp4 \
 
 ## Star 趋势
 
-<a href="https://www.star-history.com/?repos=OpenMOSS%2FMOSS-Transcribe-Diarize&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#OpenMOSS/MOSS-Transcribe-Diarize&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=OpenMOSS/MOSS-Transcribe-Diarize&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=OpenMOSS/MOSS-Transcribe-Diarize&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=OpenMOSS/MOSS-Transcribe-Diarize&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=OpenMOSS/MOSS-Transcribe-Diarize&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=OpenMOSS/MOSS-Transcribe-Diarize&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=OpenMOSS/MOSS-Transcribe-Diarize&type=date&legend=top-left" />
  </picture>
 </a>


### PR DESCRIPTION
The current star history charts are broken and no longer display repository history correctly. Update the chart links in both README files so the charts work again.