### PR TITLE
fix: make HF attention backend selection explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,15 +183,19 @@ For fine-tuning, see [FINETUNING.md](FINETUNING.md).
 ### Python Usage
 
 ```python
+import logging
 import torch
-from transformers import AutoModelForCausalLM, AutoProcessor
+from transformers import AutoProcessor
 
 from moss_transcribe_diarize import parse_transcript
+from moss_transcribe_diarize.attention import load_model_with_attention_fallback
 from moss_transcribe_diarize.inference_utils import (
     build_transcription_messages,
     generate_transcription,
     resolve_device,
 )
+
+logging.basicConfig(level=logging.INFO)
 
 model_id = "OpenMOSS-Team/MOSS-Transcribe-Diarize"
 audio_path = "audio.wav"
@@ -199,11 +203,12 @@ audio_path = "audio.wav"
 device = resolve_device("auto")
 dtype = torch.bfloat16 if device.type == "cuda" else torch.float32
 
-model = AutoModelForCausalLM.from_pretrained(
+model, attention_report = load_model_with_attention_fallback(
     model_id,
-    trust_remote_code=True,
-    dtype="auto",
-).to(dtype=dtype).to(device).eval()
+    device=device,
+    dtype=dtype,
+)
+model = model.to(dtype=dtype).to(device).eval()
 processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
 
 messages = build_transcription_messages(audio_path)
@@ -215,6 +220,7 @@ result = generate_transcription(
     do_sample=False,
     device=device,
     dtype=dtype,
+    attention_report=attention_report,
 )
 
 print(result["text"])
@@ -229,6 +235,15 @@ The message flow follows the common Qwen multimodal pattern. The chat template i
 2. `process_audio_info(messages, sampling_rate)` loads audio waveforms from the same messages.
 3. `processor(text=text, audio=audios)` computes Whisper input features and expands audio placeholders.
 4. `model.generate(...)` produces timestamped transcription and diarization text.
+
+The repository's Hugging Face loader uses an explicit attention policy instead of
+accepting a silent Transformers fallback: `flash_attention_4`, `flash_attention_3`,
+`flash_attention_2`, `sdpa`, then `eager`. Unavailable candidates and the selected
+implementation are logged. The final `eager` fallback emits a warning because it
+materializes quadratic attention tensors for long audio. Use
+`--attn-implementation` with `mtd-subtitle` or `mtd-subtitle-web` to override the
+`auto` policy. For `sdpa`, the loader probes the model's GQA shape and applies the
+available native kernel priority to each generation call.
 
 ### Serve with SGLang Omni
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -183,15 +183,19 @@ uv pip install -e ".[torch-runtime]" --torch-backend=auto
 ### Python 用法
 
 ```python
+import logging
 import torch
-from transformers import AutoModelForCausalLM, AutoProcessor
+from transformers import AutoProcessor
 
 from moss_transcribe_diarize import parse_transcript
+from moss_transcribe_diarize.attention import load_model_with_attention_fallback
 from moss_transcribe_diarize.inference_utils import (
     build_transcription_messages,
     generate_transcription,
     resolve_device,
 )
+
+logging.basicConfig(level=logging.INFO)
 
 model_id = "OpenMOSS-Team/MOSS-Transcribe-Diarize"
 audio_path = "audio.wav"
@@ -199,11 +203,12 @@ audio_path = "audio.wav"
 device = resolve_device("auto")
 dtype = torch.bfloat16 if device.type == "cuda" else torch.float32
 
-model = AutoModelForCausalLM.from_pretrained(
+model, attention_report = load_model_with_attention_fallback(
     model_id,
-    trust_remote_code=True,
-    dtype="auto",
-).to(dtype=dtype).to(device).eval()
+    device=device,
+    dtype=dtype,
+)
+model = model.to(dtype=dtype).to(device).eval()
 processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
 
 messages = build_transcription_messages(audio_path)
@@ -215,6 +220,7 @@ result = generate_transcription(
     do_sample=False,
     device=device,
     dtype=dtype,
+    attention_report=attention_report,
 )
 
 print(result["text"])
@@ -229,6 +235,12 @@ for segment in parse_transcript(result["text"]):
 2. `process_audio_info(messages, sampling_rate)` 从同一份 messages 中加载音频波形。
 3. `processor(text=text, audio=audios)` 计算 Whisper 输入特征并展开音频占位符。
 4. `model.generate(...)` 生成带时间戳的转写与说话人分离文本。
+
+仓库的 Hugging Face 加载器使用显式的 attention 策略，不接受 Transformers 的静默回退：候选顺序为
+`flash_attention_4`、`flash_attention_3`、`flash_attention_2`、`sdpa`，最后才是 `eager`。
+不可用的候选和最终选择都会写入日志；如果最终落到 `eager`，会额外发出 warning，因为它会为长音频物化二次方大小的 attention 张量。
+`mtd-subtitle` 和 `mtd-subtitle-web` 可通过 `--attn-implementation` 覆盖默认的 `auto` 策略。
+对于 `sdpa`，加载器还会按模型实际的 GQA 形状探测 native kernel，并在每次生成时应用可用 kernel 的优先级。
 
 ### 使用 SGLang Omni 部署
 

--- a/moss_transcribe_diarize/app/cli.py
+++ b/moss_transcribe_diarize/app/cli.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import time
 from pathlib import Path
 
 from moss_transcribe_diarize.inference_utils import DEFAULT_PROMPT
+from moss_transcribe_diarize.attention import ATTENTION_IMPLEMENTATIONS, AUTO_ATTENTION_IMPLEMENTATION
 from moss_transcribe_diarize.subtitle import (
     export_ass,
     export_json,
@@ -36,6 +38,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--prompt", default=DEFAULT_PROMPT)
     parser.add_argument("--device", default="auto")
     parser.add_argument("--dtype", default="bf16")
+    parser.add_argument(
+        "--attn-implementation",
+        choices=[AUTO_ATTENTION_IMPLEMENTATION, *ATTENTION_IMPLEMENTATIONS],
+        default=AUTO_ATTENTION_IMPLEMENTATION,
+        help="Attention implementation priority selector for the HF backend.",
+    )
     parser.add_argument("--max-new-tokens", type=int, default=2048)
     parser.add_argument("--max-len", type=int, default=131072)
     parser.add_argument("--decoding", choices=["greedy", "sample"], default="greedy")
@@ -45,6 +53,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
     args = parse_args()
     input_path = Path(args.input).expanduser()
     out_dir = Path(args.out_dir or f"runs/cli_{time.strftime('%Y%m%d_%H%M%S')}").expanduser()
@@ -60,7 +69,12 @@ def main() -> None:
             timeout=args.vllm_timeout,
         )
     else:
-        runner = ModelRunner(args.model, device=args.device, dtype=args.dtype)
+        runner = ModelRunner(
+            args.model,
+            device=args.device,
+            dtype=args.dtype,
+            attention_implementation=args.attn_implementation,
+        )
     result = runner.transcribe(
         input_path,
         prompt=args.prompt,

--- a/moss_transcribe_diarize/app/model_runner.py
+++ b/moss_transcribe_diarize/app/model_runner.py
@@ -7,8 +7,13 @@ from pathlib import Path
 from typing import Callable
 
 import torch
-from transformers import AutoModelForCausalLM, AutoProcessor
+from transformers import AutoProcessor
 
+from moss_transcribe_diarize.attention import (
+    AUTO_ATTENTION_IMPLEMENTATION,
+    load_model_with_attention_fallback,
+    normalize_attention_implementation,
+)
 from moss_transcribe_diarize.inference_utils import (
     DEFAULT_PROMPT,
     build_transcription_messages,
@@ -65,14 +70,17 @@ class ModelRunner:
         *,
         device: str = "auto",
         dtype: str = "bf16",
+        attention_implementation: str = AUTO_ATTENTION_IMPLEMENTATION,
     ):
         self.model_path = str(Path(model_path).expanduser())
         self.device_name = device
         self.dtype_name = dtype
+        self.attention_implementation = normalize_attention_implementation(attention_implementation)
         self._model = None
         self._processor = None
         self._device: torch.device | None = None
         self._dtype: torch.dtype | None = None
+        self._attention_report: dict | None = None
         self._lock = threading.Lock()
 
     @property
@@ -85,6 +93,11 @@ class ModelRunner:
             "path": self.model_path,
             "device": self.device_name,
             "dtype": self.dtype_name,
+            "attention": self._attention_report
+            or {
+                "requested": self.attention_implementation,
+                "selected": "unloaded",
+            },
         }
 
     def transcribe(
@@ -131,6 +144,7 @@ class ModelRunner:
                 dtype=self._dtype,
                 input_callback=on_inputs_ready,
                 token_callback=on_generated_tokens,
+                attention_report=self._attention_report,
             )
             if status_callback is not None:
                 status_callback("transcribing", 0.85, int(result["generated_tokens"]))
@@ -154,9 +168,15 @@ class ModelRunner:
         dtype = dtype_from_name(self.dtype_name)
         if device.type == "cpu":
             dtype = torch.float32
-        model = AutoModelForCausalLM.from_pretrained(self.model_path, trust_remote_code=True, dtype="auto")
+        model, attention_report = load_model_with_attention_fallback(
+            self.model_path,
+            device=device,
+            dtype=dtype,
+            requested=self.attention_implementation,
+        )
         processor = AutoProcessor.from_pretrained(self.model_path, trust_remote_code=True, fix_mistral_regex=True)
         self._model = model.to(dtype=dtype).to(device).eval()
         self._processor = processor
         self._device = device
         self._dtype = dtype
+        self._attention_report = attention_report

--- a/moss_transcribe_diarize/app/server.py
+++ b/moss_transcribe_diarize/app/server.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Any
 
 from moss_transcribe_diarize.inference_utils import DEFAULT_PROMPT
+from moss_transcribe_diarize.attention import AUTO_ATTENTION_IMPLEMENTATION
 
 from .ffmpeg import detect_ffmpeg
 from .jobs import JobManager, JobManagerError
@@ -32,6 +33,7 @@ def create_app(
     runs_dir: str | Path = "runs",
     device: str = "auto",
     dtype: str = "bf16",
+    attention_implementation: str = AUTO_ATTENTION_IMPLEMENTATION,
     prompt: str = DEFAULT_PROMPT,
     max_length: int = 131072,
     max_new_tokens: int = 2048,
@@ -62,7 +64,12 @@ def create_app(
             timeout=vllm_timeout,
         )
     else:
-        runner = ModelRunner(model_path, device=device, dtype=dtype)
+        runner = ModelRunner(
+            model_path,
+            device=device,
+            dtype=dtype,
+            attention_implementation=attention_implementation,
+        )
     manager = JobManager(
         runs_dir,
         runner,

--- a/moss_transcribe_diarize/app/web_cli.py
+++ b/moss_transcribe_diarize/app/web_cli.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import argparse
+import logging
 from pathlib import Path
 
 from moss_transcribe_diarize.inference_utils import DEFAULT_PROMPT
+from moss_transcribe_diarize.attention import ATTENTION_IMPLEMENTATIONS, AUTO_ATTENTION_IMPLEMENTATION
 
 from .cli import DEFAULT_MODEL
 from .server import create_app
@@ -22,6 +24,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--port", type=int, default=7860)
     parser.add_argument("--device", default="auto")
     parser.add_argument("--dtype", default="bf16")
+    parser.add_argument(
+        "--attn-implementation",
+        choices=[AUTO_ATTENTION_IMPLEMENTATION, *ATTENTION_IMPLEMENTATIONS],
+        default=AUTO_ATTENTION_IMPLEMENTATION,
+        help="Attention implementation priority selector for the HF backend.",
+    )
     parser.add_argument("--prompt", default=DEFAULT_PROMPT)
     parser.add_argument("--max-new-tokens", type=int, default=2048)
     parser.add_argument("--max-len", type=int, default=131072)
@@ -31,6 +39,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
     try:
         import uvicorn
     except ImportError as exc:
@@ -42,6 +51,7 @@ def main() -> None:
         runs_dir=Path(args.runs_dir).expanduser(),
         device=args.device,
         dtype=args.dtype,
+        attention_implementation=args.attn_implementation,
         prompt=args.prompt,
         max_length=args.max_len,
         max_new_tokens=args.max_new_tokens,

--- a/moss_transcribe_diarize/attention.py
+++ b/moss_transcribe_diarize/attention.py
@@ -1,0 +1,413 @@
+"""Attention implementation selection for Hugging Face inference.
+
+Transformers can silently choose ``eager`` when a requested attention
+implementation is unavailable.  That is particularly expensive for the
+long audio prompts used by MOSS-Transcribe-Diarize, so model loading goes
+through the explicit policy in this module and records every fallback.
+"""
+
+from __future__ import annotations
+
+import gc
+import importlib.util
+import logging
+import warnings
+from contextlib import contextmanager, nullcontext
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+import torch.nn.functional as F
+from transformers import AutoModelForCausalLM
+
+
+LOGGER = logging.getLogger(__name__)
+
+AUTO_ATTENTION_IMPLEMENTATION = "auto"
+ATTENTION_IMPLEMENTATIONS = (
+    "flash_attention_4",
+    "flash_attention_3",
+    "flash_attention_2",
+    "sdpa",
+    "eager",
+)
+_FLASH_IMPLEMENTATIONS = ATTENTION_IMPLEMENTATIONS[:3]
+
+
+def normalize_attention_implementation(value: str | None) -> str:
+    """Normalize and validate the user-facing attention selector."""
+    normalized = (value or AUTO_ATTENTION_IMPLEMENTATION).strip().lower()
+    aliases = {
+        "default": AUTO_ATTENTION_IMPLEMENTATION,
+        "flash3": "flash_attention_3",
+        "flash2": "flash_attention_2",
+    }
+    normalized = aliases.get(normalized, normalized)
+    if normalized not in (AUTO_ATTENTION_IMPLEMENTATION, *ATTENTION_IMPLEMENTATIONS):
+        choices = ", ".join((AUTO_ATTENTION_IMPLEMENTATION, *ATTENTION_IMPLEMENTATIONS))
+        raise ValueError(f"Unsupported attention implementation {value!r}; choose one of: {choices}.")
+    return normalized
+
+
+def _module_available(module_name: str) -> bool:
+    try:
+        return importlib.util.find_spec(module_name) is not None
+    except (ImportError, ModuleNotFoundError, ValueError):
+        return False
+
+
+def _transformers_flash_available(implementation: str) -> bool | None:
+    """Use Transformers' distribution-aware availability check when present."""
+    version = implementation.rsplit("_", 1)[-1]
+    try:
+        from transformers import utils as transformers_utils
+
+        checker = getattr(transformers_utils, f"is_flash_attn_{version}_available", None)
+        if checker is None:
+            return None
+        return bool(checker())
+    except Exception:  # noqa: BLE001 - older Transformers may not expose the checker
+        return None
+
+
+def _device_capability(device: torch.device) -> tuple[int, int] | None:
+    if device.type != "cuda" or not torch.cuda.is_available():
+        return None
+    try:
+        return tuple(torch.cuda.get_device_capability(device))
+    except (RuntimeError, AssertionError, ValueError):
+        return None
+
+
+def _flash_preflight(implementation: str, device: torch.device, dtype: torch.dtype) -> str | None:
+    """Return a reason when an external FlashAttention candidate is unavailable."""
+    if device.type != "cuda":
+        return "requires a CUDA device"
+    if dtype not in (torch.float16, torch.bfloat16):
+        return f"requires float16/bfloat16, got {dtype}"
+
+    capability = _device_capability(device)
+    if capability is None:
+        return "CUDA device capability could not be determined"
+    major, _ = capability
+    if implementation == "flash_attention_4" and major < 9:
+        return f"requires compute capability >= 9.x, got {capability}"
+    if implementation == "flash_attention_3" and major < 8:
+        return f"requires compute capability >= 8.x, got {capability}"
+
+    module_name = {
+        "flash_attention_4": "flash_attn",
+        "flash_attention_3": "flash_attn_interface",
+        "flash_attention_2": "flash_attn",
+    }[implementation]
+    if not _module_available(module_name):
+        return f"optional package/module {module_name!r} is not installed"
+    reported_available = _transformers_flash_available(implementation)
+    if reported_available is False:
+        return f"Transformers reports {implementation} unavailable in this environment"
+    return None
+
+
+def _sdpa_available() -> bool:
+    return callable(getattr(F, "scaled_dot_product_attention", None))
+
+
+def _candidate_list(
+    requested: str,
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> tuple[list[str], list[dict[str, str]]]:
+    """Build candidates and explain candidates skipped before model loading."""
+    if requested != AUTO_ATTENTION_IMPLEMENTATION:
+        return [requested], []
+
+    candidates: list[str] = []
+    attempts: list[dict[str, str]] = []
+    for implementation in _FLASH_IMPLEMENTATIONS:
+        reason = _flash_preflight(implementation, device, dtype)
+        if reason is None:
+            candidates.append(implementation)
+            continue
+        attempts.append({"backend": implementation, "status": "skipped", "reason": reason})
+        LOGGER.info("[MOSS attention] skip %s: %s", implementation, reason)
+
+    if _sdpa_available():
+        candidates.append("sdpa")
+    else:
+        reason = "torch.nn.functional.scaled_dot_product_attention is unavailable"
+        attempts.append({"backend": "sdpa", "status": "skipped", "reason": reason})
+        LOGGER.warning("[MOSS attention] skip sdpa: %s", reason)
+
+    # Eager is intentionally last.  It is retained as a compatibility escape
+    # hatch, but selecting it for this long-context model is a warning-worthy
+    # event rather than a silent Transformers default.
+    candidates.append("eager")
+    return candidates, attempts
+
+
+def _config_attention_values(model: Any) -> dict[str, str | None]:
+    config = getattr(model, "config", None)
+    values: dict[str, str | None] = {}
+    for name, item in (
+        ("model", config),
+        ("text", getattr(config, "text_config", None)),
+        ("audio", getattr(config, "audio_config", None)),
+    ):
+        value = None
+        if item is not None:
+            value = getattr(item, "_attn_implementation", None)
+            if value is None:
+                value = getattr(item, "_attn_implementation_internal", None)
+        values[name] = None if value is None else str(value)
+    return values
+
+
+def _contains_eager(values: dict[str, str | None]) -> bool:
+    return any(value == "eager" or (value or "").endswith("|eager") for value in values.values())
+
+
+def _attention_family(value: str | None) -> str | None:
+    if value is None:
+        return None
+    value = value.lower()
+    if value == "eager" or value.endswith("|eager"):
+        return "eager"
+    for version in ("4", "3", "2"):
+        if f"flash_attention_{version}" in value or f"flash-attn{version}" in value:
+            return f"flash_attention_{version}"
+    if value == "sdpa" or value.endswith("|sdpa"):
+        return "sdpa"
+    return None
+
+
+def _resolution_mismatch(requested: str, values: dict[str, str | None]) -> str | None:
+    """Return a mismatch description for a silently rewritten candidate."""
+    families = {_attention_family(value) for value in values.values() if value is not None}
+    families.discard(None)
+    if not families:
+        return None
+    expected = _attention_family(requested)
+    if expected is not None and families != {expected}:
+        return f"requested {requested}, resolved families={sorted(families)} ({values})"
+    return None
+
+
+def _release_failed_model(model: Any, device: torch.device) -> None:
+    if model is not None:
+        del model
+    gc.collect()
+    if device.type == "cuda" and torch.cuda.is_available():
+        try:
+            torch.cuda.empty_cache()
+        except Exception:  # noqa: BLE001 - cleanup must not hide the load error
+            pass
+
+
+def probe_sdpa_kernels(device: torch.device, dtype: torch.dtype) -> tuple[str, ...]:
+    """Probe native SDPA kernels and return names that can execute.
+
+    This is deliberately a small representative probe.  It tells the log
+    which native kernels are available, while the SDPA dispatcher still owns
+    the final per-shape decision during the real model forward.
+    """
+    if device.type != "cuda" or not _sdpa_available():
+        return ("math",) if _sdpa_available() else ()
+    if dtype not in (torch.float16, torch.bfloat16):
+        return ("math",)
+
+    try:
+        from torch.nn.attention import SDPBackend, sdpa_kernel
+    except (ImportError, AttributeError):
+        return ("math",)
+
+    backends = (
+        ("flash", getattr(SDPBackend, "FLASH_ATTENTION", None)),
+        ("cudnn", getattr(SDPBackend, "CUDNN_ATTENTION", None)),
+        ("efficient", getattr(SDPBackend, "EFFICIENT_ATTENTION", None)),
+        ("math", getattr(SDPBackend, "MATH", None)),
+    )
+    query = key = value = None
+    available: list[str] = []
+    try:
+        # Qwen3 uses 16 query heads and 8 KV heads.  Probe that GQA shape so
+        # the report does not claim that a kernel works merely because it can
+        # handle a same-head toy tensor.
+        query = torch.randn((1, 16, 128, 128), device=device, dtype=dtype)
+        key = torch.randn((1, 8, 128, 128), device=device, dtype=dtype)
+        value = torch.randn_like(key)
+        with torch.inference_mode():
+            for name, backend in backends:
+                if backend is None:
+                    continue
+                try:
+                    with warnings.catch_warnings():
+                        warnings.simplefilter("ignore")
+                        with sdpa_kernel(backend):
+                            F.scaled_dot_product_attention(
+                                query,
+                                key,
+                                value,
+                                is_causal=True,
+                                enable_gqa=True,
+                            )
+                    torch.cuda.synchronize(device)
+                    available.append(name)
+                except Exception:  # noqa: BLE001 - this is a capability probe
+                    continue
+    finally:
+        del query, key, value
+        try:
+            torch.cuda.empty_cache()
+        except Exception:  # noqa: BLE001 - cleanup must not hide a probe result
+            pass
+    return tuple(available)
+
+
+@contextmanager
+def attention_execution_context(report: dict[str, Any] | None):
+    """Apply the probed SDPA kernel priority during an actual model forward."""
+    if not report or report.get("selected") != "sdpa":
+        with nullcontext():
+            yield
+        return
+
+    device_name = report.get("device_type")
+    kernels = tuple(report.get("sdpa_kernels") or ())
+    if device_name != "cuda" or not kernels:
+        with nullcontext():
+            yield
+        return
+
+    try:
+        from torch.nn.attention import SDPBackend, sdpa_kernel
+    except (ImportError, AttributeError):
+        with nullcontext():
+            yield
+        return
+
+    backend_names = {
+        "flash": "FLASH_ATTENTION",
+        "cudnn": "CUDNN_ATTENTION",
+        "efficient": "EFFICIENT_ATTENTION",
+        "math": "MATH",
+    }
+    backends = [
+        getattr(SDPBackend, backend_names[name])
+        for name in kernels
+        if name in backend_names and getattr(SDPBackend, backend_names[name], None) is not None
+    ]
+    if not backends:
+        with nullcontext():
+            yield
+        return
+
+    try:
+        context = sdpa_kernel(backends, set_priority=True)
+    except TypeError:  # Older torch versions do not expose set_priority.
+        try:
+            context = sdpa_kernel(backends)
+        except Exception as exc:  # noqa: BLE001 - retain the default dispatcher
+            LOGGER.warning("[MOSS attention] could not apply SDPA priority (%s); using the default dispatcher", exc)
+            with nullcontext():
+                yield
+            return
+    except Exception as exc:  # noqa: BLE001 - retain the default dispatcher
+        LOGGER.warning("[MOSS attention] could not apply SDPA priority (%s); using the default dispatcher", exc)
+        with nullcontext():
+            yield
+        return
+    with context:
+        yield
+
+
+def load_model_with_attention_fallback(
+    model_path: str | Path,
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+    requested: str = AUTO_ATTENTION_IMPLEMENTATION,
+    model_loader: Callable[..., Any] | None = None,
+) -> tuple[Any, dict[str, Any]]:
+    """Load a model with an explicit, logged attention fallback policy."""
+    requested = normalize_attention_implementation(requested)
+    candidates, attempts = _candidate_list(requested, device=device, dtype=dtype)
+    loader = model_loader or AutoModelForCausalLM.from_pretrained
+    selected_model = None
+
+    for implementation in candidates:
+        model = None
+        try:
+            model = loader(
+                str(model_path),
+                trust_remote_code=True,
+                dtype="auto",
+                attn_implementation=implementation,
+            )
+            config_values = _config_attention_values(model)
+            # Transformers may silently turn an unavailable SDPA/Flash request
+            # into eager.  Reject that candidate so the fallback is explicit.
+            if implementation != "eager" and _contains_eager(config_values):
+                raise RuntimeError(f"Transformers resolved {implementation} to eager: {config_values}")
+            mismatch = _resolution_mismatch(implementation, config_values)
+            if mismatch is not None:
+                raise RuntimeError(f"Transformers rewrote the requested attention implementation: {mismatch}")
+
+            selected_model = model
+            report: dict[str, Any] = {
+                "requested": requested,
+                "selected": implementation,
+                "config": config_values,
+                "attempts": [*attempts, {"backend": implementation, "status": "selected"}],
+            }
+            if implementation == "sdpa":
+                try:
+                    kernels = probe_sdpa_kernels(device, dtype)
+                except Exception as exc:  # noqa: BLE001 - probing must not force an eager fallback
+                    LOGGER.warning(
+                        "[MOSS attention] SDPA kernel probe failed (%s: %s); "
+                        "keeping the SDPA dispatcher without forcing a kernel",
+                        type(exc).__name__,
+                        str(exc).splitlines()[0],
+                    )
+                    kernels = ()
+                report["sdpa_kernels"] = list(kernels)
+                report["device_type"] = device.type
+                if device.type == "cuda" and (kernels == ("math",) or not any(kernel != "math" for kernel in kernels)):
+                    LOGGER.warning(
+                        "[MOSS attention] selected sdpa, but no fused CUDA kernel passed the probe; "
+                        "long prompts may use quadratic math attention"
+                    )
+                else:
+                    LOGGER.info("[MOSS attention] SDPA native kernel capability probe (preference order): %s", kernels)
+            if implementation == "eager":
+                LOGGER.warning(
+                    "[MOSS attention] selected eager attention as the final fallback; "
+                    "long audio can require quadratic attention memory"
+                )
+            else:
+                LOGGER.info(
+                    "[MOSS attention] selected %s (requested=%s, config=%s)",
+                    implementation,
+                    requested,
+                    config_values,
+                )
+            return selected_model, report
+        except Exception as exc:  # noqa: BLE001 - each candidate must be isolated
+            reason = f"{type(exc).__name__}: {str(exc).splitlines()[0]}"
+            attempts.append({"backend": implementation, "status": "failed", "reason": reason})
+            LOGGER.warning("[MOSS attention] %s unavailable; falling back: %s", implementation, reason)
+            _release_failed_model(model, device)
+
+    details = "; ".join(f"{item['backend']}: {item.get('reason', item['status'])}" for item in attempts)
+    raise RuntimeError(f"No usable attention implementation was found ({details})")
+
+
+__all__ = [
+    "ATTENTION_IMPLEMENTATIONS",
+    "AUTO_ATTENTION_IMPLEMENTATION",
+    "attention_execution_context",
+    "load_model_with_attention_fallback",
+    "normalize_attention_implementation",
+    "probe_sdpa_kernels",
+]

--- a/moss_transcribe_diarize/inference_utils.py
+++ b/moss_transcribe_diarize/inference_utils.py
@@ -9,6 +9,8 @@ import torch
 from transformers.audio_utils import load_audio
 from transformers.generation.streamers import BaseStreamer
 
+from .attention import attention_execution_context
+
 
 DEFAULT_PROMPT = (
     "请将音频转写为文本，每一段需以起始时间戳和说话人编号"
@@ -184,6 +186,7 @@ def generate_transcription(
     dtype: torch.dtype | None = None,
     input_callback: Callable[[int], None] | None = None,
     token_callback: TokenCallback | None = None,
+    attention_report: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     device = device or next(model.parameters()).device
     dtype = dtype or next(model.parameters()).dtype
@@ -220,18 +223,19 @@ def generate_transcription(
     if streamer is not None:
         generate_kwargs["streamer"] = streamer
 
-    with torch.inference_mode(), (
-        torch.amp.autocast("cuda", dtype=dtype)
-        if device.type == "cuda" and dtype in (torch.float16, torch.bfloat16)
-        else torch.no_grad()
-    ):
-        try:
-            outputs = model.generate(**generate_kwargs)
-        except TypeError as exc:
-            if streamer is None or "streamer" not in str(exc):
-                raise
-            generate_kwargs.pop("streamer", None)
-            outputs = model.generate(**generate_kwargs)
+    with attention_execution_context(attention_report):
+        with torch.inference_mode(), (
+            torch.amp.autocast("cuda", dtype=dtype)
+            if device.type == "cuda" and dtype in (torch.float16, torch.bfloat16)
+            else torch.no_grad()
+        ):
+            try:
+                outputs = model.generate(**generate_kwargs)
+            except TypeError as exc:
+                if streamer is None or "streamer" not in str(exc):
+                    raise
+                generate_kwargs.pop("streamer", None)
+                outputs = model.generate(**generate_kwargs)
 
     generated_ids = outputs[0][prompt_len:]
     text = processor.tokenizer.decode(generated_ids, skip_special_tokens=True).strip()

--- a/tests/test_app_api.py
+++ b/tests/test_app_api.py
@@ -84,6 +84,22 @@ class AppApiTest(unittest.TestCase):
             self.assertEqual(model["path"], "moss-served")
             self.assertEqual(model["base_url"], "http://vllm.test:8000/v1")
 
+    def test_runtime_reports_hf_attention_policy_before_lazy_load(self):
+        from fastapi.testclient import TestClient
+        from moss_transcribe_diarize.app.server import create_app
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app = create_app(
+                model_path="unused-local-model",
+                runs_dir=tmpdir,
+                attention_implementation="eager",
+            )
+            runtime = TestClient(app).get("/api/runtime")
+            self.assertEqual(runtime.status_code, 200)
+            attention = runtime.json()["model"]["attention"]
+            self.assertEqual(attention["requested"], "eager")
+            self.assertEqual(attention["selected"], "unloaded")
+
     def test_job_lifecycle_and_missing_ffmpeg_render_error(self):
         from fastapi.testclient import TestClient
         from moss_transcribe_diarize.app.server import create_app

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from moss_transcribe_diarize.attention import (
+    _candidate_list,
+    load_model_with_attention_fallback,
+    normalize_attention_implementation,
+)
+
+
+class AttentionBackendTest(unittest.TestCase):
+    def test_normalize_attention_aliases_and_rejects_unknown(self):
+        self.assertEqual(normalize_attention_implementation(None), "auto")
+        self.assertEqual(normalize_attention_implementation("default"), "auto")
+        self.assertEqual(normalize_attention_implementation("flash3"), "flash_attention_3")
+        with self.assertRaises(ValueError):
+            normalize_attention_implementation("not-a-backend")
+
+    def test_auto_candidates_keep_sdpa_before_eager(self):
+        candidates, attempts = _candidate_list("auto", device=torch.device("cpu"), dtype=torch.float32)
+        self.assertEqual(candidates, ["sdpa", "eager"])
+        self.assertEqual([item["backend"] for item in attempts], [
+            "flash_attention_4",
+            "flash_attention_3",
+            "flash_attention_2",
+        ])
+
+    def test_hidden_eager_resolution_is_rejected_before_final_fallback(self):
+        calls = []
+
+        def loader(_path, **kwargs):
+            calls.append(kwargs["attn_implementation"])
+            return SimpleNamespace(
+                config=SimpleNamespace(
+                    _attn_implementation="eager",
+                    text_config=SimpleNamespace(_attn_implementation="eager"),
+                    audio_config=SimpleNamespace(_attn_implementation="eager"),
+                )
+            )
+
+        with self.assertLogs("moss_transcribe_diarize.attention", level="WARNING") as captured:
+            model, report = load_model_with_attention_fallback(
+                "fake-model",
+                device=torch.device("cpu"),
+                dtype=torch.float32,
+                model_loader=loader,
+            )
+
+        self.assertIsNotNone(model)
+        self.assertEqual(calls, ["sdpa", "eager"])
+        self.assertEqual(report["selected"], "eager")
+        self.assertTrue(any("selected eager" in line for line in captured.output))
+
+    def test_auto_falls_from_flash_candidate_to_sdpa(self):
+        calls = []
+        sdpa_model = SimpleNamespace(
+            config=SimpleNamespace(
+                _attn_implementation="sdpa",
+                text_config=SimpleNamespace(_attn_implementation="sdpa"),
+                audio_config=SimpleNamespace(_attn_implementation="sdpa"),
+            )
+        )
+
+        def fake_preflight(implementation, _device, _dtype):
+            return None if implementation == "flash_attention_3" else "unavailable in test"
+
+        def loader(_path, **kwargs):
+            implementation = kwargs["attn_implementation"]
+            calls.append(implementation)
+            if implementation == "flash_attention_3":
+                raise RuntimeError("simulated flash load failure")
+            return sdpa_model
+
+        with patch("moss_transcribe_diarize.attention._flash_preflight", side_effect=fake_preflight):
+            with patch("moss_transcribe_diarize.attention.probe_sdpa_kernels", return_value=("flash", "math")):
+                loaded, report = load_model_with_attention_fallback(
+                    "fake-model",
+                    device=torch.device("cuda"),
+                    dtype=torch.bfloat16,
+                    model_loader=loader,
+                )
+
+        self.assertIs(loaded, sdpa_model)
+        self.assertEqual(calls, ["flash_attention_3", "sdpa"])
+        self.assertEqual(report["selected"], "sdpa")
+
+    def test_sdpa_selection_is_reported(self):
+        model = SimpleNamespace(
+            config=SimpleNamespace(
+                _attn_implementation="sdpa",
+                text_config=SimpleNamespace(_attn_implementation="sdpa"),
+                audio_config=SimpleNamespace(_attn_implementation="sdpa"),
+            )
+        )
+
+        with patch(
+            "moss_transcribe_diarize.attention.probe_sdpa_kernels",
+            return_value=("flash", "math"),
+        ):
+            loaded, report = load_model_with_attention_fallback(
+                "fake-model",
+                device=torch.device("cpu"),
+                dtype=torch.float32,
+                model_loader=lambda _path, **_kwargs: model,
+            )
+
+        self.assertIs(loaded, model)
+        self.assertEqual(report["selected"], "sdpa")
+        self.assertEqual(report["config"]["text"], "sdpa")
+        self.assertEqual(report["sdpa_kernels"], ["flash", "math"])
+
+    def test_probe_failure_does_not_force_eager(self):
+        model = SimpleNamespace(
+            config=SimpleNamespace(
+                _attn_implementation="sdpa",
+                text_config=SimpleNamespace(_attn_implementation="sdpa"),
+                audio_config=SimpleNamespace(_attn_implementation="sdpa"),
+            )
+        )
+        with patch(
+            "moss_transcribe_diarize.attention.probe_sdpa_kernels",
+            side_effect=RuntimeError("probe unavailable"),
+        ):
+            loaded, report = load_model_with_attention_fallback(
+                "fake-model",
+                device=torch.device("cpu"),
+                dtype=torch.float32,
+                model_loader=lambda _path, **_kwargs: model,
+            )
+
+        self.assertIs(loaded, model)
+        self.assertEqual(report["selected"], "sdpa")
+        self.assertEqual(report["sdpa_kernels"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Make Hugging Face attention backend selection explicit and observable for long-audio inference.

## Motivation

Transformers can silently fall back to `eager` attention when a requested backend is unavailable. For long audio prompts, this materializes quadratic attention tensors and can cause CUDA OOM around 10 minutes on a 16 GB GPU.

## Changes

- Add an explicit backend priority:
  `flash_attention_4` -> `flash_attention_3` -> `flash_attention_2` -> `sdpa` -> `eager`
- Check hardware, dtype, optional FlashAttention packages, and Transformers model configuration before selecting a backend.
- Reject silent resolution of SDPA/FlashAttention to `eager`.
- Probe native SDPA kernels using the model's GQA shape.
- Apply the detected SDPA kernel priority during generation.
- Emit structured logs for skipped, failed, and selected backends.
- Emit a warning whenever `eager` is selected as the final fallback.
- Expose the requested and selected attention backend through `/api/runtime`.
- Add `--attn-implementation` to the HF CLI and web CLI.
- Update the Python usage examples and add fallback/runtime tests.

## Validation

- 46 unit tests passed.
- `pip check` passed.
- Verified with a real 30-minute AISHELL4 audio clip:
  - Selected backend: `sdpa`
  - Native kernels: `flash`, `cudnn`, `math`
  - Peak allocated memory: approximately 4.92 GiB
  - Peak reserved memory: approximately 6.06 GiB

The default remains `auto`; external FlashAttention implementations are only attempted when the environment and model support them.