### PR TITLE
fix: attention backend selection for HF inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ source .venv/bin/activate
 uv pip install -e ".[torch-runtime]" --torch-backend=auto
 ```
 
+On CUDA GPUs, the optional `flash-attn` package can be added for faster attention kernels:
+
+```bash
+uv pip install flash-attn
+```
+
 For fine-tuning, see [FINETUNING.md](FINETUNING.md).
 
 ### Python Usage
@@ -203,6 +209,7 @@ model = AutoModelForCausalLM.from_pretrained(
     model_id,
     trust_remote_code=True,
     dtype="auto",
+    attn_implementation="sdpa",  # or "flash_attention_2" with the flash-attn package installed
 ).to(dtype=dtype).to(device).eval()
 processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
 
@@ -222,6 +229,8 @@ print(result["text"])
 for segment in parse_transcript(result["text"]):
     print(segment.start, segment.end, segment.speaker, segment.text)
 ```
+
+Pass `flash_attention_2` instead of `sdpa` when the flash-attn package is installed; `eager` is only a last resort, because its memory use grows quadratically with audio length and OOMs on long recordings. The loader used by the CLI and web app picks the best available backend in this order automatically.
 
 The message flow follows the common Qwen multimodal pattern. The chat template is loaded from the model by `AutoProcessor`:
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -178,6 +178,12 @@ source .venv/bin/activate
 uv pip install -e ".[torch-runtime]" --torch-backend=auto
 ```
 
+在 CUDA GPU 上可加装可选的 `flash-attn`，以获得更快的 attention kernel：
+
+```bash
+uv pip install flash-attn
+```
+
 微调说明请参阅 [FINETUNING.md](FINETUNING.md)。
 
 ### Python 用法
@@ -203,6 +209,7 @@ model = AutoModelForCausalLM.from_pretrained(
     model_id,
     trust_remote_code=True,
     dtype="auto",
+    attn_implementation="sdpa",  # 安装了 flash-attn 包则改用 "flash_attention_2"
 ).to(dtype=dtype).to(device).eval()
 processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
 
@@ -222,6 +229,8 @@ print(result["text"])
 for segment in parse_transcript(result["text"]):
     print(segment.start, segment.end, segment.speaker, segment.text)
 ```
+
+安装了 flash-attn 包时可将 `sdpa` 改为 `flash_attention_2`；`eager` 仅作最后兜底，长音频下会因平方级的显存占用而 OOM。CLI 和 Web App 里的加载器会自动按此优先级选择 backend。
 
 消息流程遵循常见的 Qwen 多模态范式。对话模板由 `AutoProcessor` 从模型侧加载：
 

--- a/moss_transcribe_diarize/app/model_runner.py
+++ b/moss_transcribe_diarize/app/model_runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import threading
 import time
 from dataclasses import dataclass
@@ -16,6 +17,42 @@ from moss_transcribe_diarize.inference_utils import (
     generate_transcription,
     resolve_device,
 )
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _attention_candidates(device: torch.device) -> tuple[str, ...]:
+    """Attention backend priority: FlashAttention-2 > SDPA > eager."""
+    import importlib.util
+
+    if device.type == "cuda" and importlib.util.find_spec("flash_attn") is not None:
+        return ("flash_attention_2", "sdpa", "eager")
+    return ("sdpa", "eager")
+
+
+def _load_model(model_path: str, device: torch.device):
+    candidates = _attention_candidates(device)
+    for attn_implementation in candidates:
+        try:
+            model = AutoModelForCausalLM.from_pretrained(
+                model_path,
+                trust_remote_code=True,
+                dtype="auto",
+                attn_implementation=attn_implementation,
+            )
+            if attn_implementation == "eager":
+                LOGGER.warning(
+                    "Eager attention uses quadratic memory and can OOM on long audio; install flash-attn or use SDPA"
+                )
+            return model
+        except Exception:
+            if attn_implementation == candidates[-1]:
+                raise
+            LOGGER.warning(
+                "attn_implementation=%s failed; trying the next candidate",
+                attn_implementation,
+                exc_info=True,
+            )
 
 
 StatusCallback = Callable[[str, float | None, int | None], None]
@@ -114,7 +151,11 @@ class ModelRunner:
 
             def on_generated_tokens(generated_tokens: int) -> None:
                 if status_callback is not None:
-                    status_callback("transcribing", generation_progress(generated_tokens, max_new_tokens), generated_tokens)
+                    status_callback(
+                        "transcribing",
+                        generation_progress(generated_tokens, max_new_tokens),
+                        generated_tokens,
+                    )
 
             started = time.time()
             result = generate_transcription(
@@ -154,8 +195,10 @@ class ModelRunner:
         dtype = dtype_from_name(self.dtype_name)
         if device.type == "cpu":
             dtype = torch.float32
-        model = AutoModelForCausalLM.from_pretrained(self.model_path, trust_remote_code=True, dtype="auto")
-        processor = AutoProcessor.from_pretrained(self.model_path, trust_remote_code=True, fix_mistral_regex=True)
+        model = _load_model(self.model_path, device)
+        processor = AutoProcessor.from_pretrained(
+            self.model_path, trust_remote_code=True, fix_mistral_regex=True
+        )
         self._model = model.to(dtype=dtype).to(device).eval()
         self._processor = processor
         self._device = device

--- a/tests/test_model_runner.py
+++ b/tests/test_model_runner.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from moss_transcribe_diarize.app.model_runner import ModelRunner
+
+
+def load_with(*, cuda: bool, flash_installed: bool, side_effect=None) -> MagicMock:
+    with (
+        patch(
+            "moss_transcribe_diarize.app.model_runner.AutoModelForCausalLM"
+        ) as model_cls,
+        patch("moss_transcribe_diarize.app.model_runner.AutoProcessor"),
+        patch("torch.cuda.is_available", return_value=cuda),
+        patch(
+            "importlib.util.find_spec",
+            return_value=MagicMock() if flash_installed else None,
+        ),
+    ):
+        if side_effect is not None:
+            model_cls.from_pretrained.side_effect = side_effect
+        else:
+            model_cls.from_pretrained.return_value = MagicMock()
+        runner = ModelRunner(
+            "unused-local-model", device="cuda:0" if cuda else "cpu", dtype="bf16"
+        )
+        runner._ensure_loaded()
+        return model_cls.from_pretrained
+
+
+class ModelRunnerTest(unittest.TestCase):
+    def test_uses_sdpa_without_flash_attn(self):
+        from_pretrained = load_with(cuda=False, flash_installed=False)
+        self.assertEqual(
+            from_pretrained.call_args.kwargs["attn_implementation"], "sdpa"
+        )
+
+    def test_prefers_flash_attention_2_on_cuda(self):
+        from_pretrained = load_with(cuda=True, flash_installed=True)
+        self.assertEqual(
+            from_pretrained.call_args.kwargs["attn_implementation"], "flash_attention_2"
+        )
+
+    def test_falls_back_to_sdpa_when_flash_load_fails(self):
+        from_pretrained = load_with(
+            cuda=True,
+            flash_installed=True,
+            side_effect=[RuntimeError("flash-attn build mismatch"), MagicMock()],
+        )
+        requested = [
+            call.kwargs["attn_implementation"]
+            for call in from_pretrained.call_args_list
+        ]
+        self.assertEqual(requested, ["flash_attention_2", "sdpa"])
+
+    def test_falls_back_to_eager_as_last_resort(self):
+        from_pretrained = load_with(
+            cuda=False,
+            flash_installed=False,
+            side_effect=[RuntimeError("no sdpa kernel"), MagicMock()],
+        )
+        requested = [
+            call.kwargs["attn_implementation"]
+            for call in from_pretrained.call_args_list
+        ]
+        self.assertEqual(requested, ["sdpa", "eager"])
+
+    def test_last_resort_failure_propagates(self):
+        with self.assertRaises(RuntimeError):
+            load_with(
+                cuda=False,
+                flash_installed=False,
+                side_effect=[
+                    RuntimeError("no sdpa kernel"),
+                    RuntimeError("no eager either"),
+                ],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Loading the model for HF inference without an explicit `attn_implementation` lets Transformers' dispatch silently resolve to `eager` attention. With this model's long-audio prompts (up to 131k tokens), eager attention grows memory quadratically and the run OOMs on long recordings.

## Changes

- `app/model_runner.py`: `_attention_candidates()` decides the backend priority — `flash_attention_2` on CUDA when the `flash-attn` package is installed, otherwise `sdpa` — and `_load_model()` walks the chain (`flash_attention_2` → `sdpa` → `eager`), warning on each fallback. `eager` remains only as a last-resort escape hatch and logs a clear warning about the OOM risk.
- `README.md` / `README_zh.md`: Environment Setup gains the optional `uv pip install flash-attn` step; the Python usage snippet pins `attn_implementation="sdpa"` with guidance on when to use `flash_attention_2`.
- `tests/test_model_runner.py`: covers backend order with/without flash-attn, flash→sdpa fallback, sdpa→eager last-resort fallback, and error propagation when every candidate fails.

## Why this works with minimal code

Transformers ≥ 5.6 (the pinned minimum) rejects an explicitly requested but unsupported backend instead of silently downgrading to `eager`, so a failed candidate can simply advance to the next one — no preflight probing or post-load config verification needed. `sdpa` is always available with the project's `torch>=2.8`.

## Relation to #39

This supersedes the reverted #39 with a much smaller footprint: the backend policy lives in two helpers in `model_runner.py` instead of a new 413-line `attention.py` module, and introduces no CLI flags, runtime reporting, or SDPA kernel probing (+146/-3 lines across 4 files vs +679/-26 across 10).

## Test plan

- [x] `pytest tests/` → 44 passed (Python 3.12, torch 2.13, transformers 5.16)
