### PR TITLE
docs: add FunASR ecosystem deployment path

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,11 +373,11 @@ and Transformers. Because MOSS-Transcribe-Diarize produces transcription,
 timestamps, and speaker labels in one pass, applications do not need to attach
 separate external VAD or speaker-diarization models.
 
-FunASR 1.4.8 or newer can normalize an existing vLLM service's official
+FunASR 1.4.12 or newer can normalize an existing vLLM service's official
 speaker-attributed response into the common `sentence_info` contract:
 
 ```bash
-pip install "funasr>=1.4.8"
+pip install "funasr>=1.4.12"
 ```
 
 ```python
@@ -403,6 +403,7 @@ model or weight issues that belong in this repository:
 
 - [FunASR deployment guide](https://github.com/modelscope/FunASR/blob/main/docs/moss_transcribe_diarize.md)
 - [FunASR production deployment page](https://www.funasr.com/en/deploy/moss-transcribe-diarize.html)
+- [FunClip 2.2.1: speaker-aware SRT and per-speaker clip export](https://github.com/modelscope/FunClip/releases/tag/v2.2.1)
 
 MOSS-Transcribe-Diarize remains an OpenMOSS model under Apache-2.0; the FunASR
 integration is an ecosystem deployment path, not a transfer of model ownership.

--- a/README.md
+++ b/README.md
@@ -373,6 +373,29 @@ and Transformers. Because MOSS-Transcribe-Diarize produces transcription,
 timestamps, and speaker labels in one pass, applications do not need to attach
 separate external VAD or speaker-diarization models.
 
+FunASR 1.4.8 or newer can normalize an existing vLLM service's official
+speaker-attributed response into the common `sentence_info` contract:
+
+```bash
+pip install "funasr>=1.4.8"
+```
+
+```python
+from funasr import AutoModel
+
+model = AutoModel(
+    model="OpenMOSS-Team/MOSS-Transcribe-Diarize",
+    backend="vllm",
+    vllm_base_url="http://127.0.0.1:8898/v1",
+    vllm_model="moss-transcribe-diarize",
+    vllm_response_format="diarized_json",
+    disable_update=True,
+)
+result = model.generate("audio.wav", max_completion_tokens=8192)[0]
+for segment in result["sentence_info"]:
+    print(segment["start"], segment["end"], segment["spk"], segment["text"])
+```
+
 The guide pins the model and serving revisions, documents the response contract
 of each backend, and includes an H100-verified vLLM smoke test. It also explains
 the boundary between deployment issues handled in the FunASR ecosystem and

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ MOSS-Transcribe-Diarize 0.9B supports 50+ languages.
   - [Python Usage](#python-usage)
   - [Serve with SGLang Omni](#serve-with-sglang-omni)
   - [Serve with vLLM](#serve-with-vllm)
+  - [Use in the FunASR Ecosystem](#use-in-the-funasr-ecosystem)
   - [Custom Prompt and Hotwords](#custom-prompt-and-hotwords)
   - [Subtitle Web App](#subtitle-web-app)
 - [Citation](#citation)
@@ -363,6 +364,25 @@ curl http://localhost:8000/v1/audio/transcriptions \
   -F response_format="json" \
   -F temperature="0"
 ```
+
+### Use in the FunASR Ecosystem
+
+[FunASR](https://github.com/modelscope/FunASR) maintains a production-oriented
+deployment guide for this third-party OpenMOSS model across vLLM, SGLang Omni,
+and Transformers. Because MOSS-Transcribe-Diarize produces transcription,
+timestamps, and speaker labels in one pass, applications do not need to attach
+separate external VAD or speaker-diarization models.
+
+The guide pins the model and serving revisions, documents the response contract
+of each backend, and includes an H100-verified vLLM smoke test. It also explains
+the boundary between deployment issues handled in the FunASR ecosystem and
+model or weight issues that belong in this repository:
+
+- [FunASR deployment guide](https://github.com/modelscope/FunASR/blob/main/docs/moss_transcribe_diarize.md)
+- [FunASR production deployment page](https://www.funasr.com/en/deploy/moss-transcribe-diarize.html)
+
+MOSS-Transcribe-Diarize remains an OpenMOSS model under Apache-2.0; the FunASR
+integration is an ecosystem deployment path, not a transfer of model ownership.
 
 ### Custom Prompt and Hotwords
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -369,10 +369,10 @@ curl http://localhost:8000/v1/audio/transcriptions \
 
 [FunASR](https://github.com/modelscope/FunASR) 为这个 OpenMOSS 第三方模型维护了面向生产的部署指南，覆盖 vLLM、SGLang Omni 与 Transformers。MOSS-Transcribe-Diarize 可在一次推理中同时生成转写、时间戳和说话人标签，因此应用侧无需再外挂独立的 VAD 或说话人分离模型。
 
-FunASR 1.4.8 及以上版本可连接已有的 vLLM 服务，并将官方说话人分段响应统一为 `sentence_info`：
+FunASR 1.4.12 及以上版本可连接已有的 vLLM 服务，并将官方说话人分段响应统一为 `sentence_info`：
 
 ```bash
-pip install "funasr>=1.4.8"
+pip install "funasr>=1.4.12"
 ```
 
 ```python
@@ -395,6 +395,7 @@ for segment in result["sentence_info"]:
 
 - [FunASR 部署指南](https://github.com/modelscope/FunASR/blob/main/docs/moss_transcribe_diarize_zh.md)
 - [FunASR 产品级部署页](https://www.funasr.com/deploy/moss-transcribe-diarize.html)
+- [FunClip 2.2.1：说话人 SRT 与按说话人剪辑](https://github.com/modelscope/FunClip/releases/tag/v2.2.1)
 
 MOSS-Transcribe-Diarize 仍是 OpenMOSS 基于 Apache-2.0 发布的模型；FunASR 提供的是生态部署入口，不代表模型归属发生变化。
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -42,6 +42,7 @@ MOSS-Transcribe-Diarize 0.9B 支持 50+ 种语言。
   - [Python 用法](#python-用法)
   - [使用 SGLang Omni 部署](#使用-sglang-omni-部署)
   - [使用 vLLM 部署](#使用-vllm-部署)
+  - [接入 FunASR 生态](#接入-funasr-生态)
   - [自定义 Prompt 与热词](#自定义-prompt-与热词)
   - [字幕 Web 应用](#字幕-web-应用)
 - [引用](#引用)
@@ -363,6 +364,17 @@ curl http://localhost:8000/v1/audio/transcriptions \
   -F response_format="json" \
   -F temperature="0"
 ```
+
+### 接入 FunASR 生态
+
+[FunASR](https://github.com/modelscope/FunASR) 为这个 OpenMOSS 第三方模型维护了面向生产的部署指南，覆盖 vLLM、SGLang Omni 与 Transformers。MOSS-Transcribe-Diarize 可在一次推理中同时生成转写、时间戳和说话人标签，因此应用侧无需再外挂独立的 VAD 或说话人分离模型。
+
+该指南固定了模型与服务端版本，分别说明各后端的响应契约，并提供了在 H100 上验证过的 vLLM 冒烟测试；同时明确哪些部署问题由 FunASR 生态承接，哪些模型或权重问题应在本仓库反馈：
+
+- [FunASR 部署指南](https://github.com/modelscope/FunASR/blob/main/docs/moss_transcribe_diarize_zh.md)
+- [FunASR 产品级部署页](https://www.funasr.com/deploy/moss-transcribe-diarize.html)
+
+MOSS-Transcribe-Diarize 仍是 OpenMOSS 基于 Apache-2.0 发布的模型；FunASR 提供的是生态部署入口，不代表模型归属发生变化。
 
 ### 自定义 Prompt 与热词
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -369,6 +369,28 @@ curl http://localhost:8000/v1/audio/transcriptions \
 
 [FunASR](https://github.com/modelscope/FunASR) 为这个 OpenMOSS 第三方模型维护了面向生产的部署指南，覆盖 vLLM、SGLang Omni 与 Transformers。MOSS-Transcribe-Diarize 可在一次推理中同时生成转写、时间戳和说话人标签，因此应用侧无需再外挂独立的 VAD 或说话人分离模型。
 
+FunASR 1.4.8 及以上版本可连接已有的 vLLM 服务，并将官方说话人分段响应统一为 `sentence_info`：
+
+```bash
+pip install "funasr>=1.4.8"
+```
+
+```python
+from funasr import AutoModel
+
+model = AutoModel(
+    model="OpenMOSS-Team/MOSS-Transcribe-Diarize",
+    backend="vllm",
+    vllm_base_url="http://127.0.0.1:8898/v1",
+    vllm_model="moss-transcribe-diarize",
+    vllm_response_format="diarized_json",
+    disable_update=True,
+)
+result = model.generate("audio.wav", max_completion_tokens=8192)[0]
+for segment in result["sentence_info"]:
+    print(segment["start"], segment["end"], segment["spk"], segment["text"])
+```
+
 该指南固定了模型与服务端版本，分别说明各后端的响应契约，并提供了在 H100 上验证过的 vLLM 冒烟测试；同时明确哪些部署问题由 FunASR 生态承接，哪些模型或权重问题应在本仓库反馈：
 
 - [FunASR 部署指南](https://github.com/modelscope/FunASR/blob/main/docs/moss_transcribe_diarize_zh.md)


### PR DESCRIPTION
## Summary

- add bilingual FunASR ecosystem entries to the Quickstart table of contents
- link the released FunASR 1.4.12 deployment path for vLLM, SGLang Omni, Transformers, and LocalAI/GGUF
- include a runnable AutoModel example for vLLM diarized_json speaker segments
- link FunClip 2.2.1 for speaker-aware SRT and per-speaker clip export
- clarify that applications do not attach an external VAD or speaker model, while OpenMOSS retains model ownership and Apache-2.0 attribution

## Verification

- exact signed+DCO head: 43a7c31885a745b2e53f58c447fc7226553582e2
- all Python fences in both READMEs parse
- PyPI FunASR 1.4.12, FunClip 2.2.1, and both deployed FunASR product pages return HTTP 200
- git diff --check passes

This PR changes README files only. The runtime and model implementation remain owned and maintained by OpenMOSS; FunASR provides the ecosystem adapter and deployment contract.