### PR TITLE
Update Star History charts with sealed token

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,8 +424,8 @@ If you use MOSS-Transcribe-Diarize, please cite the technical report:
 
 <a href="https://www.star-history.com/?repos=OpenMOSS%2FMOSS-Transcribe-Diarize&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=OpenMOSS/MOSS-Transcribe-Diarize&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=OpenMOSS/MOSS-Transcribe-Diarize&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=OpenMOSS/MOSS-Transcribe-Diarize&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=OpenMOSS/MOSS-Transcribe-Diarize&type=date&theme=dark&legend=top-left&sealed_token=mH12i8gD5lfNQgijI1XFwTSYdeRDBJ_jK-UAJ-UQVFqrJitaSp_zNqaFjXRxMkVkxFVjdUMdWhtSZsTbSrMyCkZ6AFh1shbM5VicsLvSvVeXRUo5gBJ8X8r8DQTyp9Mg9-xsvGmNdacD5LGWOgtqsDadz1rplKKXAmYxW01QFjkjmISHcZz6tubRdJ72" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=OpenMOSS/MOSS-Transcribe-Diarize&type=date&legend=top-left&sealed_token=mH12i8gD5lfNQgijI1XFwTSYdeRDBJ_jK-UAJ-UQVFqrJitaSp_zNqaFjXRxMkVkxFVjdUMdWhtSZsTbSrMyCkZ6AFh1shbM5VicsLvSvVeXRUo5gBJ8X8r8DQTyp9Mg9-xsvGmNdacD5LGWOgtqsDadz1rplKKXAmYxW01QFjkjmISHcZz6tubRdJ72" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=OpenMOSS/MOSS-Transcribe-Diarize&type=date&legend=top-left&sealed_token=mH12i8gD5lfNQgijI1XFwTSYdeRDBJ_jK-UAJ-UQVFqrJitaSp_zNqaFjXRxMkVkxFVjdUMdWhtSZsTbSrMyCkZ6AFh1shbM5VicsLvSvVeXRUo5gBJ8X8r8DQTyp9Mg9-xsvGmNdacD5LGWOgtqsDadz1rplKKXAmYxW01QFjkjmISHcZz6tubRdJ72" />
  </picture>
 </a>

--- a/README_zh.md
+++ b/README_zh.md
@@ -423,8 +423,8 @@ mtd-subtitle /path/to/input.mp4 \
 
 <a href="https://www.star-history.com/?repos=OpenMOSS%2FMOSS-Transcribe-Diarize&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=OpenMOSS/MOSS-Transcribe-Diarize&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=OpenMOSS/MOSS-Transcribe-Diarize&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=OpenMOSS/MOSS-Transcribe-Diarize&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=OpenMOSS/MOSS-Transcribe-Diarize&type=date&theme=dark&legend=top-left&sealed_token=mH12i8gD5lfNQgijI1XFwTSYdeRDBJ_jK-UAJ-UQVFqrJitaSp_zNqaFjXRxMkVkxFVjdUMdWhtSZsTbSrMyCkZ6AFh1shbM5VicsLvSvVeXRUo5gBJ8X8r8DQTyp9Mg9-xsvGmNdacD5LGWOgtqsDadz1rplKKXAmYxW01QFjkjmISHcZz6tubRdJ72" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=OpenMOSS/MOSS-Transcribe-Diarize&type=date&legend=top-left&sealed_token=mH12i8gD5lfNQgijI1XFwTSYdeRDBJ_jK-UAJ-UQVFqrJitaSp_zNqaFjXRxMkVkxFVjdUMdWhtSZsTbSrMyCkZ6AFh1shbM5VicsLvSvVeXRUo5gBJ8X8r8DQTyp9Mg9-xsvGmNdacD5LGWOgtqsDadz1rplKKXAmYxW01QFjkjmISHcZz6tubRdJ72" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=OpenMOSS/MOSS-Transcribe-Diarize&type=date&legend=top-left&sealed_token=mH12i8gD5lfNQgijI1XFwTSYdeRDBJ_jK-UAJ-UQVFqrJitaSp_zNqaFjXRxMkVkxFVjdUMdWhtSZsTbSrMyCkZ6AFh1shbM5VicsLvSvVeXRUo5gBJ8X8r8DQTyp9Mg9-xsvGmNdacD5LGWOgtqsDadz1rplKKXAmYxW01QFjkjmISHcZz6tubRdJ72" />
  </picture>
 </a>


### PR DESCRIPTION
Replace the broken unsealed Star History endpoints in both English and Chinese READMEs with the official embed code generated by star-history.com. Both light and dark SVG endpoints were verified to return the correct repository chart.